### PR TITLE
Feat/webhooks allow override pact url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ test {
 	systemProperty("pact.provider.version", System.getenv("GIT_COMMIT") == null ? "" : System.getenv("GIT_COMMIT"))
 	systemProperty("pact.provider.branch", System.getenv("GIT_BRANCH") == null ? "" : System.getenv("GIT_BRANCH"))
 	
+	// only publish verification results from CI allowing developers to run tests locally and debug, without affecting broker results
+	// only verification results from a known source (such at a commit in a VCS and a reproducible environment such as CI) should be published
+	systemProperty("pact.verifier.publishResults", System.getenv("PACT_BROKER_PUBLISH_VERIFICATION_RESULTS") == null ? "false" : "true")
+	
 	// Consumer version selectors for dynamically fetching pacts
 	// https://docs.pact.io/implementation_guides/jvm/provider/junit#selecting-the-pacts-to-verify-with-consumer-version-selectors-4314
 	// Runs when the provider code changes

--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,27 @@ test {
 	useJUnitPlatform()
 
 	// These properties need to be set on the test JVM process
+	//https://docs.pact.io/implementation_guides/jvm/provider/junit#using-java-system-properties
+
+
+	// required variables for fetching dynamic pacts, & publishing verification results
 	systemProperty("pact.provider.version", System.getenv("GIT_COMMIT") == null ? "" : System.getenv("GIT_COMMIT"))
-	// systemProperty("pact.provider.tag", System.getenv("GIT_BRANCH") == null ? "" : System.getenv("GIT_BRANCH"))
 	systemProperty("pact.provider.branch", System.getenv("GIT_BRANCH") == null ? "" : System.getenv("GIT_BRANCH"))
-	systemProperty("pactbroker.consumerversionselectors.rawjson", "[{\"mainBranch\":true}]")
-	systemProperty("pact.verifier.publishResults", System.getenv("PACT_BROKER_PUBLISH_VERIFICATION_RESULTS") == null ? "false" : "true")
+	
+	// Consumer version selectors for dynamically fetching pacts
+	// https://docs.pact.io/implementation_guides/jvm/provider/junit#selecting-the-pacts-to-verify-with-consumer-version-selectors-4314
+	// Runs when the provider code changes
+	systemProperty("pactbroker.consumerversionselectors.rawjson", "[{\"mainBranch\":true},{\"deployedOrReleased\":true},{\"matchingBranch\":true}]")
+	// Allow just the changed pact triggered by webhook, to be verified, ignoring the consumer version selectors above
+	// https://docs.pact.io/implementation_guides/jvm/provider/junit#allowing-just-the-changed-pact-specified-in-a-webhook-to-be-verified-406
+	// Runs when the consumer contract changes
+	systemProperty("pact.filter.pacturl", System.getenv("PACT_URL") == null ? null : System.getenv("PACT_URL"))
+	systemProperty("pact.filter.consumers", System.getenv("PACT_URL") == null ? null : System.getenv("PACT_URL").split("/consumer/")[1])
+
+	// pending pacts
+	systemProperty("pactbroker.enablePending", true)
+
+	// work in progress pacts
+	systemProperty("pactbroker.includeWipPactsSince", java.time.LocalDate.now().minusMonths(6).format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+
 }

--- a/src/test/java/com/example/springboot/ProductsPactTest.java
+++ b/src/test/java/com/example/springboot/ProductsPactTest.java
@@ -18,7 +18,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @Provider("pactflow-example-provider-springboot")
-@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST}",providerBranch = "${GIT_COMMIT}", enablePendingPacts = "true", authentication = @PactBrokerAuth(token = "${PACT_BROKER_TOKEN}"))
+@AllowOverridePactUrl
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST}",providerBranch = "${GIT_COMMIT}", authentication = @PactBrokerAuth(token = "${PACT_BROKER_TOKEN}"))
 class ProductsPactTest {
 
   @Autowired


### PR DESCRIPTION
Adds support for recommended Pact Nirvana workflow

- Uses consumer version selectors to dynamically fetch pacts when the provider code changes
- Use `contract_requiring_verification_published` webhook, and pact-jvm override to only verify the incoming pact url, ignoring consumer version selectors. This is triggered by changes in the consumer code
- Add work in progress pacts for the last 6 months of contracts, dynamically from date of provider test execution
- Add enablePendingPacts, to avoid consumer pacts breaking provider workflows and stopping them from deploying